### PR TITLE
Limit slug length

### DIFF
--- a/src/Resized.php
+++ b/src/Resized.php
@@ -30,6 +30,11 @@ class Resized
     private $defaultOptions = [];
 
     /**
+     * @var int
+     */
+    private $maxSlugLength;
+
+    /**
     * Constructor
     *
     * @param string $key
@@ -92,15 +97,18 @@ class Resized
     * @param int    $height
     * @param string $title
     * @param array  $options
+    * @param int    $maxLength
     *
-    * @param string
+    * @return  string
     */
-    public function process($url, $width = '', $height = '', $title = '', $options = [])
+    public function process($url, $width = '', $height = '', $title = '', $options = [], $maxLength = 100)
     {
         //If invalid URL passed, set to default image
         if (empty($url) || filter_var($url, FILTER_VALIDATE_URL) === false) {
             $url = $this->defaultImage;
         }
+
+        $this->maxSlugLength = $maxLength;
 
         $data = json_encode([
             'url' => $url,
@@ -130,7 +138,7 @@ class Resized
 
 
     /**
-     * Get seo slug and file extention
+     * Get seo slug and file extension
      *
      * @param string $url
      * @param string $title
@@ -145,9 +153,9 @@ class Resized
             $filename = $this->slug(pathinfo($url, PATHINFO_FILENAME));
         }
 
-        $extention = pathinfo($url, PATHINFO_EXTENSION);
-        if (!empty($extention)) {
-            return $filename.'.'.$extention;
+        $extension = pathinfo($url, PATHINFO_EXTENSION);
+        if (!empty($extension)) {
+            return $filename.'.'.$extension;
         }
 
         return $filename;
@@ -162,6 +170,9 @@ class Resized
     */
     private function slug($str)
     {
+        // Limit characters
+        $str = substr($str, 0, $this->maxSlugLength);
+
         // replace non letter or digits by -
         $str = preg_replace('~[^\\pL\d]+~u', '-', $str);
 

--- a/src/Resized.php
+++ b/src/Resized.php
@@ -29,10 +29,12 @@ class Resized
      */
     private $defaultOptions = [];
 
+
     /**
      * @var int
      */
-    private $maxSlugLength;
+    private $maxSlugLength = 100;
+
 
     /**
     * Constructor
@@ -90,6 +92,17 @@ class Resized
     }
 
     /**
+     * Set max slug length.
+     *
+     * @param int $length
+     */
+    public function setMaxSlugLength(int $length)
+    {
+        $this->maxSlugLength = $length;
+    }
+
+
+    /**
     * Process image
     *
     * @param string $url
@@ -97,18 +110,15 @@ class Resized
     * @param int    $height
     * @param string $title
     * @param array  $options
-    * @param int    $maxLength
     *
     * @return  string
     */
-    public function process($url, $width = '', $height = '', $title = '', $options = [], $maxLength = 100)
+    public function process($url, $width = '', $height = '', $title = '', $options = [])
     {
         //If invalid URL passed, set to default image
         if (empty($url) || filter_var($url, FILTER_VALIDATE_URL) === false) {
             $url = $this->defaultImage;
         }
-
-        $this->maxSlugLength = $maxLength;
 
         $data = json_encode([
             'url' => $url,
@@ -155,10 +165,11 @@ class Resized
 
         $extension = pathinfo($url, PATHINFO_EXTENSION);
         if (!empty($extension)) {
-            return $filename.'.'.$extension;
+            $maxLength = $this->maxSlugLength - strlen('.'.$extension);
+            return substr($filename, 0, $maxLength).'.'.$extension;
         }
 
-        return $filename;
+        return substr($filename, 0, $this->maxSlugLength);
     }
 
     /**
@@ -170,9 +181,6 @@ class Resized
     */
     private function slug($str)
     {
-        // Limit characters
-        $str = substr($str, 0, $this->maxSlugLength);
-
         // replace non letter or digits by -
         $str = preg_replace('~[^\\pL\d]+~u', '-', $str);
 


### PR DESCRIPTION
In the filename part of the url, we allow decorating of the url with some seo-friendly text. This url is used in the cache key when the generated image is stored in S3. If the slug is too long, S3 will 404 on the resulting url.
Limit the decorated part of the slug to 100 characters as a sane default.